### PR TITLE
Improve spectral I/O and apply formatting

### DIFF
--- a/lg_spectra/__init__.py
+++ b/lg_spectra/__init__.py
@@ -1,6 +1,6 @@
 """Little Garden HPLC/DAD spectral analysis toolkit."""
 
-from .io import load_any
+from .io import load_any, load_folder, save_spec
 from .preprocess import apply_pipeline
 from .sticks import pick_sticks, Stick
 from .features import compute_features
@@ -10,7 +10,16 @@ from .library import add_replicate, build_index
 from .sim import sim_traces
 
 __all__ = [
-    'load_any', 'apply_pipeline', 'pick_sticks', 'Stick',
-    'compute_features', 'sticks_to_vector', 'score',
-    'add_replicate', 'build_index', 'sim_traces'
+    "load_any",
+    "load_folder",
+    "save_spec",
+    "apply_pipeline",
+    "pick_sticks",
+    "Stick",
+    "compute_features",
+    "sticks_to_vector",
+    "score",
+    "add_replicate",
+    "build_index",
+    "sim_traces",
 ]

--- a/lg_spectra/cli.py
+++ b/lg_spectra/cli.py
@@ -1,55 +1,54 @@
 """Command line interface for Little Garden HPLC/DAD toolkit."""
+
 from __future__ import annotations
 
 import argparse
-import json
 from pathlib import Path
 
-import numpy as np
 
 from .io import load_any
 from .preprocess import apply_pipeline
 from .sticks import pick_sticks
 from .features import compute_features
 from .library import add_replicate, build_index
-from .matching import score
-from .sim import sim_traces
 
 
 def fp_make(input_folder: Path, out_folder: Path) -> None:
     out_folder.mkdir(parents=True, exist_ok=True)
-    for lam_file in input_folder.glob('*_lam.npy'):
+    for lam_file in input_folder.glob("*_lam.npy"):
         lam, spec, meta = load_any(lam_file)
         y = spec[0] if spec.ndim > 1 else spec
-        y_hat = apply_pipeline(lam, y, [{'op': 'snv'}, {'op': 'savgol', 'win': 7, 'poly': 2}])
+        y_hat = apply_pipeline(
+            lam, y, [{"op": "snv"}, {"op": "savgol", "win": 7, "poly": 2}]
+        )
         sticks = pick_sticks(lam, y_hat)
         fp = compute_features(lam, y_hat, sticks)
-        fp['meta'] = meta
-        out_path = out_folder / (lam_file.stem.replace('_lam', '') + '.pms.json')
+        fp["meta"] = meta
+        out_path = out_folder / (lam_file.stem.replace("_lam", "") + ".pms.json")
         add_replicate(fp, out_path)
 
 
 def main(argv: list[str] | None = None) -> None:
-    parser = argparse.ArgumentParser(prog='lgfp')
-    sub = parser.add_subparsers(dest='cmd', required=True)
+    parser = argparse.ArgumentParser(prog="lgfp")
+    sub = parser.add_subparsers(dest="cmd", required=True)
 
-    fp_parser = sub.add_parser('fp', help='fingerprint utilities')
-    fp_sub = fp_parser.add_subparsers(dest='subcmd', required=True)
-    make_p = fp_sub.add_parser('make')
-    make_p.add_argument('input_folder', type=Path)
-    make_p.add_argument('--out', type=Path, required=True)
+    fp_parser = sub.add_parser("fp", help="fingerprint utilities")
+    fp_sub = fp_parser.add_subparsers(dest="subcmd", required=True)
+    make_p = fp_sub.add_parser("make")
+    make_p.add_argument("input_folder", type=Path)
+    make_p.add_argument("--out", type=Path, required=True)
 
-    lib_parser = sub.add_parser('lib', help='library tools')
-    lib_sub = lib_parser.add_subparsers(dest='subcmd', required=True)
-    build_p = lib_sub.add_parser('build')
-    build_p.add_argument('db_folder', type=Path)
+    lib_parser = sub.add_parser("lib", help="library tools")
+    lib_sub = lib_parser.add_subparsers(dest="subcmd", required=True)
+    build_p = lib_sub.add_parser("build")
+    build_p.add_argument("db_folder", type=Path)
 
     args = parser.parse_args(argv)
-    if args.cmd == 'fp' and args.subcmd == 'make':
+    if args.cmd == "fp" and args.subcmd == "make":
         fp_make(args.input_folder, args.out)
-    elif args.cmd == 'lib' and args.subcmd == 'build':
+    elif args.cmd == "lib" and args.subcmd == "build":
         build_index(args.db_folder)
 
 
-if __name__ == '__main__':  # pragma: no cover
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/lg_spectra/features.py
+++ b/lg_spectra/features.py
@@ -1,4 +1,5 @@
 """Feature extraction from spectra and sticks."""
+
 from __future__ import annotations
 
 from typing import Dict, List
@@ -26,10 +27,10 @@ def _bandpower(lam: np.ndarray, y: np.ndarray) -> List[float]:
 
 def _phash(y: np.ndarray) -> str:
     small = np.interp(np.linspace(0, len(y) - 1, 32), np.arange(len(y)), y)
-    coeffs = dct(small, norm='ortho')[:16]
+    coeffs = dct(small, norm="ortho")[:16]
     med = np.median(coeffs[1:])
-    bits = ''.join('1' if c > med else '0' for c in coeffs[1:])
-    return 'phash_v1:' + hex(int(bits, 2))[2:]
+    bits = "".join("1" if c > med else "0" for c in coeffs[1:])
+    return "phash_v1:" + hex(int(bits, 2))[2:]
 
 
 def compute_features(lam: np.ndarray, y: np.ndarray, sticks: List[Stick]) -> Dict:
@@ -38,21 +39,21 @@ def compute_features(lam: np.ndarray, y: np.ndarray, sticks: List[Stick]) -> Dic
     ratios = (rel[1:] / rel[0]) if len(rel) > 1 else np.array([])
     y_norm = y / np.max(y) if np.max(y) else y
     feats = {
-        'sticks': [s.__dict__ for s in sticks],
-        'ratios': ratios.tolist(),
-        'entropy': float(entropy(np.abs(y_norm) + 1e-12)),
-        'bandpower': _bandpower(lam, y_norm),
-        'dct16': dct(y_norm, norm='ortho')[:16].tolist(),
-        'hash': _phash(y_norm),
-        'global': {
-            'lambda_mean': float(np.average(lam, weights=y_norm)),
-            'skew': float(skew(y_norm)),
-            'kurt': float(kurtosis(y_norm)),
+        "sticks": [s.__dict__ for s in sticks],
+        "ratios": ratios.tolist(),
+        "entropy": float(entropy(np.abs(y_norm) + 1e-12)),
+        "bandpower": _bandpower(lam, y_norm),
+        "dct16": dct(y_norm, norm="ortho")[:16].tolist(),
+        "hash": _phash(y_norm),
+        "global": {
+            "lambda_mean": float(np.average(lam, weights=y_norm)),
+            "skew": float(skew(y_norm)),
+            "kurt": float(kurtosis(y_norm)),
         },
-        'quality': {
-            'snr': float(np.max(rel) / (np.std(y_norm) + 1e-9)),
-            'purity': float(np.max(rel) / (np.sum(rel) + 1e-9)),
-            'n_sticks': int(len(sticks)),
+        "quality": {
+            "snr": float(np.max(rel) / (np.std(y_norm) + 1e-9)),
+            "purity": float(np.max(rel) / (np.sum(rel) + 1e-9)),
+            "n_sticks": int(len(sticks)),
         },
     }
     return feats

--- a/lg_spectra/fingerprint.py
+++ b/lg_spectra/fingerprint.py
@@ -1,4 +1,5 @@
 """Convenience launcher for the spectral fingerprint GUI."""
+
 from .gui import run
 
 if __name__ == "__main__":

--- a/lg_spectra/gui.py
+++ b/lg_spectra/gui.py
@@ -1,4 +1,5 @@
 """PyQt6 GUI application for spectral analysis."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -22,7 +23,7 @@ from .matching import score
 class MainWindow(QtWidgets.QMainWindow):
     def __init__(self) -> None:
         super().__init__()
-        self.setWindowTitle('Little Garden HPLC/DAD')
+        self.setWindowTitle("Little Garden HPLC/DAD")
         self.current_fp: Dict | None = None
         self.library_index: Dict[str, Dict] = {}
         self.current_folder: Optional[Path] = None
@@ -30,21 +31,21 @@ class MainWindow(QtWidgets.QMainWindow):
         self._init_ui()
 
     def _init_ui(self) -> None:
-        self.spectra_plot = pg.PlotWidget(title='Spectra')
-        self.ms_plot = pg.PlotWidget(title='Pseudo-MS')
+        self.spectra_plot = pg.PlotWidget(title="Spectra")
+        self.ms_plot = pg.PlotWidget(title="Pseudo-MS")
         self.feature_table = QtWidgets.QTableWidget()
         self.match_table = QtWidgets.QTableWidget()
         self.file_list = QtWidgets.QListWidget()
 
-        dock1 = QtWidgets.QDockWidget('Spectra', self)
+        dock1 = QtWidgets.QDockWidget("Spectra", self)
         dock1.setWidget(self.spectra_plot)
-        dock2 = QtWidgets.QDockWidget('Pseudo-MS', self)
+        dock2 = QtWidgets.QDockWidget("Pseudo-MS", self)
         dock2.setWidget(self.ms_plot)
-        dock3 = QtWidgets.QDockWidget('Features', self)
+        dock3 = QtWidgets.QDockWidget("Features", self)
         dock3.setWidget(self.feature_table)
-        dock4 = QtWidgets.QDockWidget('Match', self)
+        dock4 = QtWidgets.QDockWidget("Match", self)
         dock4.setWidget(self.match_table)
-        dock5 = QtWidgets.QDockWidget('Dateien', self)
+        dock5 = QtWidgets.QDockWidget("Dateien", self)
         dock5.setWidget(self.file_list)
 
         self.addDockWidget(Qt.DockWidgetArea.LeftDockWidgetArea, dock1)
@@ -55,17 +56,17 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.file_list.itemSelectionChanged.connect(self._display_selected)
 
-        open_action = QAction('Ordner laden', self)
+        open_action = QAction("Ordner laden", self)
         open_action.triggered.connect(self.open_folder)
-        add_action = QAction('Spektren hinzufügen', self)
+        add_action = QAction("Spektren hinzufügen", self)
         add_action.triggered.connect(self.add_spectra)
-        lib_action = QAction('Bibliothek laden', self)
+        lib_action = QAction("Bibliothek laden", self)
         lib_action.triggered.connect(self.open_library)
-        match_action = QAction('Abgleichen', self)
+        match_action = QAction("Abgleichen", self)
         match_action.triggered.connect(self.match_spectrum)
-        export_action = QAction('Fingerprint exportieren', self)
+        export_action = QAction("Fingerprint exportieren", self)
         export_action.triggered.connect(self.export_fingerprint)
-        toolbar = self.addToolBar('Main')
+        toolbar = self.addToolBar("Main")
         toolbar.addAction(open_action)
         toolbar.addAction(add_action)
         toolbar.addAction(lib_action)
@@ -73,27 +74,27 @@ class MainWindow(QtWidgets.QMainWindow):
         toolbar.addAction(export_action)
 
     def open_folder(self) -> None:
-        folder = QtWidgets.QFileDialog.getExistingDirectory(self, 'Ordner wählen')
+        folder = QtWidgets.QFileDialog.getExistingDirectory(self, "Ordner wählen")
         if not folder:
             return
         self.load_folder(Path(folder))
 
     def open_library(self) -> None:
-        folder = QtWidgets.QFileDialog.getExistingDirectory(self, 'Bibliothek wählen')
+        folder = QtWidgets.QFileDialog.getExistingDirectory(self, "Bibliothek wählen")
         if not folder:
             return
         self.load_library(Path(folder))
 
     def load_folder(self, folder: Path) -> None:
         self.current_folder = folder
-        files = sorted(folder.glob('*_lam.npy'))
+        files = sorted(folder.glob("*_lam.npy"))
         if not files:
             return
         self.loaded_spectra.clear()
         self.file_list.clear()
         for p in files:
             lam, spec, meta = load_any(p)
-            base = p.name.replace('_lam.npy', '')
+            base = p.name.replace("_lam.npy", "")
             self.loaded_spectra[base] = (lam, spec, meta)
             self.file_list.addItem(base)
         if self.file_list.count():
@@ -102,9 +103,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def add_spectra(self, paths: Optional[List[Path]] = None) -> None:
         if paths is None:
             files, _ = QtWidgets.QFileDialog.getOpenFileNames(
-                self,
-                'Spektren wählen',
-                filter='Spektren (*.npy *.npz *.csv)'
+                self, "Spektren wählen", filter="Spektren (*.npy *.npz *.csv)"
             )
             if not files:
                 return
@@ -112,9 +111,9 @@ class MainWindow(QtWidgets.QMainWindow):
         for p in paths:
             lam, spec, meta = load_any(p)
             name = p.name
-            if name.endswith('_lam.npy'):
+            if name.endswith("_lam.npy"):
                 base = name[:-8]
-            elif name.endswith('_spec.npy'):
+            elif name.endswith("_spec.npy"):
                 base = name[:-9]
             else:
                 base = p.stem
@@ -131,24 +130,26 @@ class MainWindow(QtWidgets.QMainWindow):
         base = items[0].text()
         lam, spec, _ = self.loaded_spectra[base]
         y = spec[0] if spec.ndim > 1 else spec
-        y_hat = apply_pipeline(lam, y, [{'op': 'snv'}, {'op': 'savgol', 'win': 7, 'poly': 2}])
+        y_hat = apply_pipeline(
+            lam, y, [{"op": "snv"}, {"op": "savgol", "win": 7, "poly": 2}]
+        )
         self.spectra_plot.clear()
-        self.spectra_plot.plot(lam, y, pen='r')
-        self.spectra_plot.plot(lam, y_hat, pen='g')
-        sticks = pick_sticks(lam, y_hat, {'k': 6})
+        self.spectra_plot.plot(lam, y, pen="r")
+        self.spectra_plot.plot(lam, y_hat, pen="g")
+        sticks = pick_sticks(lam, y_hat, {"k": 6})
         self.ms_plot.clear()
         for s in sticks:
-            self.ms_plot.plot([s.lambda_nm, s.lambda_nm], [0, s.rel_intensity], pen='b')
+            self.ms_plot.plot([s.lambda_nm, s.lambda_nm], [0, s.rel_intensity], pen="b")
         fp = compute_features(lam, y_hat, sticks)
         self.current_fp = fp
         self.feature_table.setColumnCount(2)
-        self.feature_table.setRowCount(len(fp['bandpower']))
-        for i, bp in enumerate(fp['bandpower']):
-            self.feature_table.setItem(i, 0, QtWidgets.QTableWidgetItem(f'Band {i}'))
-            self.feature_table.setItem(i, 1, QtWidgets.QTableWidgetItem(f'{bp:.3f}'))
+        self.feature_table.setRowCount(len(fp["bandpower"]))
+        for i, bp in enumerate(fp["bandpower"]):
+            self.feature_table.setItem(i, 0, QtWidgets.QTableWidgetItem(f"Band {i}"))
+            self.feature_table.setItem(i, 1, QtWidgets.QTableWidgetItem(f"{bp:.3f}"))
 
     def load_library(self, folder: Path) -> None:
-        index_file = folder / 'library_index.json'
+        index_file = folder / "library_index.json"
         if index_file.exists():
             self.library_index = json.loads(index_file.read_text())
         else:
@@ -160,32 +161,34 @@ class MainWindow(QtWidgets.QMainWindow):
         rows = []
         for name, entry in self.library_index.items():
             lib_entry = {
-                'sticks': entry.get('sticks', []),
-                'ratios': entry.get('ratios_mean', []),
-                'bandpower': entry.get('bandpower_mean', []),
-                'hash': entry.get('hash')
+                "sticks": entry.get("sticks", []),
+                "ratios": entry.get("ratios_mean", []),
+                "bandpower": entry.get("bandpower_mean", []),
+                "hash": entry.get("hash"),
             }
             sc = score(self.current_fp, lib_entry)
-            rows.append((name, sc['S'], sc['S_cos'], sc['S_ratio']))
+            rows.append((name, sc["S"], sc["S_cos"], sc["S_ratio"]))
         rows.sort(key=lambda r: r[1], reverse=True)
         self.match_table.setColumnCount(4)
-        self.match_table.setHorizontalHeaderLabels(['Analyte', 'Score', 'Cos', 'Ratio'])
+        self.match_table.setHorizontalHeaderLabels(["Analyte", "Score", "Cos", "Ratio"])
         self.match_table.setRowCount(len(rows))
         for i, (name, s_total, s_cos, s_ratio) in enumerate(rows):
             self.match_table.setItem(i, 0, QtWidgets.QTableWidgetItem(name))
-            self.match_table.setItem(i, 1, QtWidgets.QTableWidgetItem(f'{s_total:.3f}'))
-            self.match_table.setItem(i, 2, QtWidgets.QTableWidgetItem(f'{s_cos:.3f}'))
-            self.match_table.setItem(i, 3, QtWidgets.QTableWidgetItem(f'{s_ratio:.3f}'))
+            self.match_table.setItem(i, 1, QtWidgets.QTableWidgetItem(f"{s_total:.3f}"))
+            self.match_table.setItem(i, 2, QtWidgets.QTableWidgetItem(f"{s_cos:.3f}"))
+            self.match_table.setItem(i, 3, QtWidgets.QTableWidgetItem(f"{s_ratio:.3f}"))
 
     def export_fingerprint(self, path: Optional[Path] = None) -> None:
         if not self.current_fp:
             return
         if path is None:
-            file, _ = QtWidgets.QFileDialog.getSaveFileName(self, 'Fingerprint speichern', filter='JSON (*.json)')
+            file, _ = QtWidgets.QFileDialog.getSaveFileName(
+                self, "Fingerprint speichern", filter="JSON (*.json)"
+            )
             if not file:
                 return
             path = Path(file)
-        with Path(path).open('w', encoding='utf8') as fh:
+        with Path(path).open("w", encoding="utf8") as fh:
             json.dump(self.current_fp, fh, indent=2)
 
 
@@ -197,5 +200,5 @@ def run() -> None:
     app.exec()
 
 
-if __name__ == '__main__':  # pragma: no cover - manual run
+if __name__ == "__main__":  # pragma: no cover - manual run
     run()

--- a/lg_spectra/io.py
+++ b/lg_spectra/io.py
@@ -1,62 +1,214 @@
-"""Data loading utilities for Little Garden HPLC/DAD spectra.
+"""Data I/O helpers for Little Garden spectral fingerprints."""
 
-The :func:`load_any` function accepts paths to NPY/NPZ/CSV files and
-returns wavelength and spectral arrays along with a meta dictionary.
-"""
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict, Tuple
+from typing import Dict, Iterable, List
 import json
+import time
+
 import numpy as np
 
 
-def _load_npy_pair(path: Path) -> Tuple[np.ndarray, np.ndarray]:
-    """Load *_lam.npy and *_spec.npy files."""
-    if path.name.endswith('_lam.npy'):
+_WL_ALIASES = ["wavelength", "lam", "lambda_nm"]
+_INT_ALIASES = ["intensity", "i"]
+_ABS_ALIASES = ["absorbance_mau", "absorbance", "a_mau"]
+
+
+def _find_key(keys: Iterable[str], aliases: List[str]) -> str | None:
+    for a in aliases:
+        if a in keys:
+            return a
+    return None
+
+
+def _load_npy_pair(path: Path) -> tuple[np.ndarray, np.ndarray]:
+    """Load *_lam.npy/*_spec.npy files."""
+    if path.name.endswith("_lam.npy"):
         lam_path = path
-        spec_path = path.with_name(path.name.replace('_lam.npy', '_spec.npy'))
-    elif path.name.endswith('_spec.npy'):
+        spec_path = path.with_name(path.name.replace("_lam.npy", "_spec.npy"))
+    elif path.name.endswith("_spec.npy"):
         spec_path = path
-        lam_path = path.with_name(path.name.replace('_spec.npy', '_lam.npy'))
+        lam_path = path.with_name(path.name.replace("_spec.npy", "_lam.npy"))
     else:
-        raise ValueError('Numpy files must end with _lam.npy or _spec.npy')
+        raise ValueError("Numpy files must end with _lam.npy or _spec.npy")
 
-    lam = np.load(lam_path)
-    spec = np.load(spec_path)
-    return lam.astype(float), spec.astype(float)
+    if not lam_path.exists() or not spec_path.exists():
+        raise FileNotFoundError(
+            f"Missing companion file for '{path.name}'. Expected '{lam_path.name}' and '{spec_path.name}'."
+        )
+    lam = np.load(lam_path).astype(float)
+    spec = np.load(spec_path).astype(float)
+    return lam, spec
 
 
-def load_any(path: str | Path) -> Tuple[np.ndarray, np.ndarray, Dict]:
+def load_any(path: str | Path) -> Dict:
     """Load spectral data from ``path``.
 
-    Parameters
-    ----------
-    path:
-        Path to ``.npy``, ``.npz`` or ``.csv`` file. For NPY files the
-        companion *_lam.npy/*_spec.npy pair is detected automatically.
-
-    Returns
-    -------
-    lam, spec, meta
-        ``lam`` is a 1-D wavelength array, ``spec`` can be 1-D or 2-D
-        spectral data, and ``meta`` contains information about the
-        origin of the data (currently only file name and time stamp).
+    Returns a dict with keys ``wavelength``, ``intensity`` and ``absorbance_mau``
+    (latter two may be ``None``) plus a ``meta`` dictionary.
     """
-    p = Path(path)
-    meta = {"file": p.name}
-    if p.suffix == '.npz':
-        data = np.load(p)
-        lam = data['wavelength']
-        key = 'absorbance_mau' if 'absorbance_mau' in data else 'intensity'
-        spec = data[key]
-    elif p.suffix == '.npy':
-        lam, spec = _load_npy_pair(p)
-    elif p.suffix == '.csv':
-        arr = np.loadtxt(p, delimiter=',', skiprows=1)
-        lam, spec = arr[:, 0], arr[:, 1]
-    else:
-        raise ValueError(f'Unsupported file type: {p.suffix}')
 
-    meta['mtime'] = p.stat().st_mtime
-    return lam, spec, meta
+    p = Path(path)
+    meta = {"filename": p.name, "mtime": p.stat().st_mtime}
+
+    if p.suffix == ".npz":
+        data = np.load(p, allow_pickle=True)
+        key_wl = _find_key(data.files, _WL_ALIASES)
+        key_int = _find_key(data.files, _INT_ALIASES)
+        key_abs = _find_key(data.files, _ABS_ALIASES)
+        if key_wl is None:
+            raise KeyError("wavelength key missing in NPZ")
+        lam = data[key_wl].astype(float)
+        intensity = data[key_int].astype(float) if key_int else None
+        absorb = data[key_abs].astype(float) if key_abs else None
+        if "meta" in data:
+            try:
+                meta.update(json.loads(str(data["meta"].item())))
+            except Exception:
+                pass
+
+    elif p.suffix == ".npy":
+        if p.name.endswith("_lam.npy"):
+            lam, spec = _load_npy_pair(p)
+            intensity = spec
+            absorb = None
+        elif p.name.endswith("_spec.npy"):
+            lam_path = p.with_name(p.name.replace("_spec.npy", "_lam.npy"))
+            if lam_path.exists():
+                lam, spec = _load_npy_pair(p)
+                intensity = spec
+                absorb = None
+            else:
+                arr = np.load(p).astype(float)
+                if arr.ndim == 2 and 2 in arr.shape:
+                    if arr.shape[0] == 2:
+                        lam, spec = arr[0], arr[1]
+                    elif arr.shape[1] == 2:
+                        lam, spec = arr[:, 0], arr[:, 1]
+                    else:
+                        raise ValueError(
+                            f"Standalone _spec.npy must contain wavelength as first row or column: '{p.name}'"
+                        )
+                    intensity = spec
+                    absorb = None
+                else:
+                    raise FileNotFoundError(
+                        f"Missing companion _lam.npy for '{p.name}' and no embedded wavelength"
+                    )
+        else:
+            arr = np.load(p).astype(float)
+            if arr.ndim == 2 and 2 in arr.shape:
+                if arr.shape[0] == 2:
+                    lam, spec = arr[0], arr[1]
+                elif arr.shape[1] == 2:
+                    lam, spec = arr[:, 0], arr[:, 1]
+                else:
+                    raise ValueError(
+                        f"Standalone _spec.npy must contain wavelength as first row or column: '{p.name}'"
+                    )
+                intensity = spec
+                absorb = None
+            else:
+                raise ValueError(f"Unsupported NPY format for '{p.name}'")
+
+    elif p.suffix == ".csv":
+        arr = np.genfromtxt(p, delimiter=",", names=True, dtype=float)
+        names = {n.lower(): n for n in arr.dtype.names or []}
+        key_wl = _find_key(names, _WL_ALIASES)
+        if key_wl is None:
+            raise KeyError("wavelength column missing in CSV")
+        lam = arr[names[key_wl]].astype(float)
+        key_int = _find_key(names, _INT_ALIASES)
+        key_abs = _find_key(names, _ABS_ALIASES)
+        intensity = arr[names[key_int]].astype(float) if key_int else None
+        absorb = arr[names[key_abs]].astype(float) if key_abs else None
+    else:
+        raise ValueError(f"Unsupported file type: {p.suffix}")
+
+    return {
+        "wavelength": lam,
+        "intensity": intensity,
+        "absorbance_mau": absorb,
+        "meta": meta,
+    }
+
+
+def load_folder(
+    path: str | Path,
+    patterns: Iterable[str] = ("*.npz", "*.csv", "*_spec.npy", "*_lam.npy"),
+) -> List[Dict]:
+    """Load all spectra found in ``path`` matching ``patterns``."""
+
+    folder = Path(path)
+    files: List[Path] = []
+    for pat in patterns:
+        files.extend(folder.glob(pat))
+
+    results: List[Dict] = []
+    handled: set[Path] = set()
+    for f in sorted(files):
+        if f in handled:
+            continue
+        if f.name.endswith("_lam.npy"):
+            spec = f.with_name(f.name.replace("_lam.npy", "_spec.npy"))
+            handled.add(f)
+            if spec.exists():
+                handled.add(spec)
+            results.append(load_any(f))
+        elif f.name.endswith("_spec.npy"):
+            lam = f.with_name(f.name.replace("_spec.npy", "_lam.npy"))
+            handled.add(f)
+            if lam.exists():
+                handled.add(lam)
+            results.append(load_any(f))
+        else:
+            handled.add(f)
+            results.append(load_any(f))
+    return results
+
+
+def save_spec(
+    path: str | Path,
+    wavelength: np.ndarray,
+    *,
+    intensity: np.ndarray | None = None,
+    absorbance_mau: np.ndarray | None = None,
+    exposure: float = 0.0,
+    gain: float = 0.0,
+    stack_ms: float = 0.0,
+    stack_n: int = 1,
+    snr: float | None = None,
+    flicker: float | None = None,
+    source: str = "",
+    matrix: str | None = None,
+    roi: str | None = None,
+) -> None:
+    """Save spectral data to a compressed NPZ file."""
+
+    p = Path(path)
+    meta = {
+        "filename": p.name,
+        "timestamp": time.time(),
+        "source": source,
+    }
+    if matrix is not None:
+        meta["matrix"] = matrix
+    if roi is not None:
+        meta["roi"] = roi
+
+    np.savez_compressed(
+        p,
+        wavelength=np.asarray(wavelength, dtype=float),
+        intensity=None if intensity is None else np.asarray(intensity, dtype=float),
+        absorbance_mau=(
+            None if absorbance_mau is None else np.asarray(absorbance_mau, dtype=float)
+        ),
+        exposure=float(exposure),
+        gain=float(gain),
+        stack_ms=float(stack_ms),
+        stack_n=int(stack_n),
+        snr=None if snr is None else float(snr),
+        flicker=None if flicker is None else float(flicker),
+        meta=json.dumps(meta),
+    )

--- a/lg_spectra/library.py
+++ b/lg_spectra/library.py
@@ -1,4 +1,5 @@
 """Library management utilities."""
+
 from __future__ import annotations
 
 import json
@@ -11,7 +12,7 @@ def add_replicate(fp: Dict, out_path: str | Path) -> None:
     """Save fingerprint ``fp`` to ``out_path`` in JSON format."""
     p = Path(out_path)
     p.parent.mkdir(parents=True, exist_ok=True)
-    with p.open('w', encoding='utf8') as fh:
+    with p.open("w", encoding="utf8") as fh:
         json.dump(fp, fh, indent=2)
 
 
@@ -22,20 +23,20 @@ def build_index(db_root: str | Path) -> Dict:
     for analyte_dir in db_root.iterdir():
         if not analyte_dir.is_dir():
             continue
-        reps = list((analyte_dir / 'replicates').glob('*.json'))
+        reps = list((analyte_dir / "replicates").glob("*.json"))
         if not reps:
             continue
         feats = [json.loads(p.read_text()) for p in reps]
-        ratios = np.array([f.get('ratios', []) for f in feats], dtype=float)
-        bandpower = np.array([f.get('bandpower', []) for f in feats], dtype=float)
+        ratios = np.array([f.get("ratios", []) for f in feats], dtype=float)
+        bandpower = np.array([f.get("bandpower", []) for f in feats], dtype=float)
         index[analyte_dir.name] = {
-            'ratios_mean': ratios.mean(axis=0).tolist() if ratios.size else [],
-            'ratios_std': ratios.std(axis=0).tolist() if ratios.size else [],
-            'bandpower_mean': bandpower.mean(axis=0).tolist() if bandpower.size else [],
-            'bandpower_std': bandpower.std(axis=0).tolist() if bandpower.size else [],
-            'sticks': feats[0].get('sticks', []),
+            "ratios_mean": ratios.mean(axis=0).tolist() if ratios.size else [],
+            "ratios_std": ratios.std(axis=0).tolist() if ratios.size else [],
+            "bandpower_mean": bandpower.mean(axis=0).tolist() if bandpower.size else [],
+            "bandpower_std": bandpower.std(axis=0).tolist() if bandpower.size else [],
+            "sticks": feats[0].get("sticks", []),
         }
-    out_file = db_root / 'library_index.json'
-    with out_file.open('w', encoding='utf8') as fh:
+    out_file = db_root / "library_index.json"
+    with out_file.open("w", encoding="utf8") as fh:
         json.dump(index, fh, indent=2)
     return index

--- a/lg_spectra/matching.py
+++ b/lg_spectra/matching.py
@@ -1,9 +1,11 @@
 """Fingerprint matching utilities."""
+
 from __future__ import annotations
 
 from typing import Dict
 import numpy as np
 
+from .sticks import Stick
 from .vectorize import sticks_to_vector
 
 
@@ -25,23 +27,29 @@ def _ratio_score(a: list, b: list) -> float:
 
 def score(sample_fp: Dict, library_entry: Dict) -> Dict[str, float]:
     """Compute similarity scores between a sample fingerprint and a library entry."""
-    vec_sample = sticks_to_vector([Stick(**s) for s in sample_fp['sticks']]) if 'sticks' in sample_fp else np.array([])
-    vec_lib = sticks_to_vector([Stick(**s) for s in library_entry['sticks']]) if 'sticks' in library_entry else np.array([])
+    vec_sample = (
+        sticks_to_vector([Stick(**s) for s in sample_fp["sticks"]])
+        if "sticks" in sample_fp
+        else np.array([])
+    )
+    vec_lib = (
+        sticks_to_vector([Stick(**s) for s in library_entry["sticks"]])
+        if "sticks" in library_entry
+        else np.array([])
+    )
     s_cos = _cosine(vec_sample, vec_lib)
-    s_ratio = _ratio_score(sample_fp.get('ratios', []), library_entry.get('ratios', []))
-    s_hash = 1.0 if sample_fp.get('hash') == library_entry.get('hash') else 0.0
-    purity = sample_fp.get('quality', {}).get('purity', 0.0)
-    rt_pen = library_entry.get('rt_min') and sample_fp.get('rt_min')
-    s_rt = 1 - abs(sample_fp.get('rt_min', 0) - library_entry.get('rt_min', 0)) / max(library_entry.get('rt_min', 1), 1)
+    s_ratio = _ratio_score(sample_fp.get("ratios", []), library_entry.get("ratios", []))
+    s_hash = 1.0 if sample_fp.get("hash") == library_entry.get("hash") else 0.0
+    purity = sample_fp.get("quality", {}).get("purity", 0.0)
+    s_rt = 1 - abs(sample_fp.get("rt_min", 0) - library_entry.get("rt_min", 0)) / max(
+        library_entry.get("rt_min", 1), 1
+    )
     score_total = 0.5 * s_cos + 0.2 * s_ratio + 0.1 * s_rt + 0.1 * purity + 0.1 * s_hash
     return {
-        'S_cos': s_cos,
-        'S_ratio': s_ratio,
-        'S_rt': s_rt,
-        'Purity': purity,
-        'S_hash': s_hash,
-        'S': score_total,
+        "S_cos": s_cos,
+        "S_ratio": s_ratio,
+        "S_rt": s_rt,
+        "Purity": purity,
+        "S_hash": s_hash,
+        "S": score_total,
     }
-
-# needed dataclass import at top
-from .sticks import Stick

--- a/lg_spectra/preprocess.py
+++ b/lg_spectra/preprocess.py
@@ -1,4 +1,5 @@
 """Spectral preprocessing pipelines."""
+
 from __future__ import annotations
 
 from typing import Dict, Iterable
@@ -23,20 +24,22 @@ def area_norm(y: np.ndarray) -> np.ndarray:
 
 
 def moving_avg(y: np.ndarray, n: int) -> np.ndarray:
-    c = np.convolve(y, np.ones(n) / n, mode='same')
+    c = np.convolve(y, np.ones(n) / n, mode="same")
     return c
 
 
 _OPERATORS = {
-    'rolling_min': rolling_min,
-    'snv': lambda y: snv(y),
-    'area_norm': lambda y: area_norm(y),
-    'savgol': lambda y, win=7, poly=2: savgol_filter(y, win, poly),
-    'moving_avg': lambda y, n=3: moving_avg(y, n),
+    "rolling_min": rolling_min,
+    "snv": lambda y: snv(y),
+    "area_norm": lambda y: area_norm(y),
+    "savgol": lambda y, win=7, poly=2: savgol_filter(y, win, poly),
+    "moving_avg": lambda y, n=3: moving_avg(y, n),
 }
 
 
-def apply_pipeline(lam: np.ndarray, y: np.ndarray, config: Iterable[Dict]) -> np.ndarray:
+def apply_pipeline(
+    lam: np.ndarray, y: np.ndarray, config: Iterable[Dict]
+) -> np.ndarray:
     """Apply a sequence of preprocessing steps described by ``config``.
 
     Each element in ``config`` is a mapping with key ``op`` specifying
@@ -44,10 +47,10 @@ def apply_pipeline(lam: np.ndarray, y: np.ndarray, config: Iterable[Dict]) -> np
     """
     y_hat = np.asarray(y, dtype=float)
     for step in config:
-        op = step['op']
+        op = step["op"]
         func = _OPERATORS.get(op)
         if func is None:
-            raise ValueError(f'Unknown operator {op}')
-        kwargs = {k: v for k, v in step.items() if k != 'op'}
+            raise ValueError(f"Unknown operator {op}")
+        kwargs = {k: v for k, v in step.items() if k != "op"}
         y_hat = func(y_hat, **kwargs)
     return y_hat

--- a/lg_spectra/sim.py
+++ b/lg_spectra/sim.py
@@ -1,4 +1,5 @@
 """Selected ion monitoring style traces from spectral data."""
+
 from __future__ import annotations
 
 from typing import Dict, Sequence

--- a/lg_spectra/sticks.py
+++ b/lg_spectra/sticks.py
@@ -1,4 +1,5 @@
 """Peak picking and stick fingerprint generation."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -15,7 +16,9 @@ class Stick:
     prominence: float
 
 
-def pick_sticks(lam: np.ndarray, y: np.ndarray, params: dict | None = None) -> List[Stick]:
+def pick_sticks(
+    lam: np.ndarray, y: np.ndarray, params: dict | None = None
+) -> List[Stick]:
     """Detect peaks and return the top-K as sticks.
 
     Parameters
@@ -27,16 +30,23 @@ def pick_sticks(lam: np.ndarray, y: np.ndarray, params: dict | None = None) -> L
         ``distance`` forwarded to :func:`find_peaks`.
     """
     params = params or {}
-    k = params.get('k', 6)
-    peaks, props = find_peaks(y, prominence=params.get('prominence', 0.001),
-                              distance=params.get('distance', 5))
+    k = params.get("k", 6)
+    peaks, props = find_peaks(
+        y,
+        prominence=params.get("prominence", 0.001),
+        distance=params.get("distance", 5),
+    )
     if len(peaks) == 0:
         return []
     widths = peak_widths(y, peaks, rel_height=0.5)
     rel = y[peaks] / y[peaks].max() * 100.0
     sticks = [
-        Stick(lambda_nm=float(lam[p]), rel_intensity=float(r),
-              width_nm=float(w), prominence=float(props['prominences'][i]))
+        Stick(
+            lambda_nm=float(lam[p]),
+            rel_intensity=float(r),
+            width_nm=float(w),
+            prominence=float(props["prominences"][i]),
+        )
         for i, (p, r, w) in enumerate(zip(peaks, rel, widths[0]))
     ]
     sticks.sort(key=lambda s: s.rel_intensity, reverse=True)

--- a/lg_spectra/vectorize.py
+++ b/lg_spectra/vectorize.py
@@ -1,4 +1,5 @@
 """Vectorisation utilities for matching."""
+
 from __future__ import annotations
 
 from typing import List
@@ -7,7 +8,9 @@ import numpy as np
 from .sticks import Stick
 
 
-def sticks_to_vector(sticks: List[Stick], wl_min: int = 360, wl_max: int = 800) -> np.ndarray:
+def sticks_to_vector(
+    sticks: List[Stick], wl_min: int = 360, wl_max: int = 800
+) -> np.ndarray:
     """Convert stick list to 1-nm binned vector."""
     vec = np.zeros(wl_max - wl_min + 1, dtype=float)
     for s in sticks:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+import numpy as np
+
+from lg_spectra.io import load_any, load_folder, save_spec
+
+
+def test_save_and_load_spec_npz(tmp_path: Path) -> None:
+    lam = np.linspace(400, 700, 5)
+    inten = np.random.rand(5)
+    out = tmp_path / "test.npz"
+    save_spec(out, lam, intensity=inten, source="unit")
+    data = load_any(out)
+    assert np.allclose(data["wavelength"], lam)
+    assert np.allclose(data["intensity"], inten)
+    assert data["meta"]["filename"] == "test.npz"
+
+
+def test_load_folder_with_various_files(tmp_path: Path) -> None:
+    lam = np.linspace(400, 700, 5)
+    inten = np.random.rand(5)
+
+    # NPY pair
+    np.save(tmp_path / "sample_lam.npy", lam)
+    np.save(tmp_path / "sample_spec.npy", inten)
+
+    # CSV with aliases
+    csv_path = tmp_path / "sample.csv"
+    data = np.column_stack([lam, inten])
+    header = "lambda_nm,I"
+    np.savetxt(csv_path, data, delimiter=",", header=header, comments="")
+
+    # Embedded spec
+    np.save(tmp_path / "embedded_spec.npy", np.vstack([lam, inten]))
+
+    items = load_folder(tmp_path)
+    assert len(items) == 3
+    bases = {d["meta"]["filename"] for d in items}
+    assert {"sample_lam.npy", "sample.csv", "embedded_spec.npy"} <= bases
+
+
+def test_orphan_spec_raises(tmp_path: Path) -> None:
+    inten = np.random.rand(5)
+    orphan = tmp_path / "orphan_spec.npy"
+    np.save(orphan, inten)
+    try:
+        load_any(orphan)
+    except FileNotFoundError as e:
+        assert "Missing companion" in str(e)
+    else:  # pragma: no cover - should not happen
+        assert False


### PR DESCRIPTION
## Summary
- expand `io` module with alias-aware `load_any`, bulk `load_folder`, and `save_spec`
- move matching imports to module level and expose new I/O helpers
- apply ruff and black formatting across package

## Testing
- `python -m lg_spectra.gui` *(fails: ImportError: libGL.so.1)*
- `python - <<'PY'
import lg_spectra.io
import lg_spectra.preprocess
import lg_spectra.sticks
import lg_spectra.features
import lg_spectra.vectorize
import lg_spectra.matching
import lg_spectra.library
import lg_spectra.sim
import lg_spectra.cli
print('imports ok')
PY`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5289d3cec8331bc16dbbdb8b11e7d