### PR TITLE
feat: expand CLI and GUI with theming and quality checks

### DIFF
--- a/lg_spectra/cli.py
+++ b/lg_spectra/cli.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+import sys
 
 import numpy as np
 
 from .io import load_any
-from .preprocess import apply_pipeline
+from .preprocess import apply_pipeline, sanitize_spectrum
 from .sticks import pick_sticks
 from .features import compute_features
 from .library import add_replicate, build_index
@@ -21,35 +22,108 @@ def fp_make(input_folder: Path, out_folder: Path) -> None:
     for lam_file in input_folder.glob('*_lam.npy'):
         lam, spec, meta = load_any(lam_file)
         y = spec[0] if spec.ndim > 1 else spec
+        lam, y, notes = sanitize_spectrum(lam, y)
         y_hat = apply_pipeline(lam, y, [{'op': 'snv'}, {'op': 'savgol', 'win': 7, 'poly': 2}])
         sticks = pick_sticks(lam, y_hat)
         fp = compute_features(lam, y_hat, sticks)
         fp['meta'] = meta
-        out_path = out_folder / (lam_file.stem.replace('_lam', '') + '.pms.json')
-        add_replicate(fp, out_path)
+        fp['warnings'].extend(notes)
+        base = lam_file.stem.replace('_lam', '')
+        out_json = out_folder / f"{base}.pms.json"
+        add_replicate(fp, out_json)
+        np.savez(out_folder / f"{base}.npz", lam=lam, spec=y_hat)
+        if fp['warnings']:
+            print(f"{base}: {'; '.join(fp['warnings'])}")
 
 
-def main(argv: list[str] | None = None) -> None:
+def lib_build(input_folder: Path, out_file: Path) -> None:
+    index = build_index(input_folder)
+    out_file.write_text(json.dumps(index, indent=2))
+
+
+def match_sample(sample_file: Path, lib_file: Path, top: int, json_out: Path | None) -> None:
+    lam, spec, _ = load_any(sample_file)
+    y = spec[0] if spec.ndim > 1 else spec
+    lam, y, _ = sanitize_spectrum(lam, y)
+    y_hat = apply_pipeline(lam, y, [{'op': 'snv'}, {'op': 'savgol', 'win': 7, 'poly': 2}])
+    sticks = pick_sticks(lam, y_hat)
+    fp = compute_features(lam, y_hat, sticks)
+    library = json.loads(Path(lib_file).read_text())
+    rows = []
+    for name, entry in library.items():
+        lib_entry = {
+            'sticks': entry.get('sticks', []),
+            'ratios': entry.get('ratios_mean', []),
+            'bandpower': entry.get('bandpower_mean', []),
+            'hash': entry.get('hash'),
+        }
+        sc = score(fp, lib_entry)
+        rows.append({'name': name, **sc})
+    rows.sort(key=lambda r: r['S'], reverse=True)
+    for r in rows[:top]:
+        print(f"{r['name']}\t{r['S']:.3f}")
+    if json_out:
+        json_out.write_text(json.dumps(rows[:top], indent=2))
+
+
+def sim_export(in_file: Path, out_file: Path, channels: list[float]) -> None:
+    lam, spec, _ = load_any(in_file)
+    if spec.ndim != 2:
+        raise ValueError('SIM export requires time-resolved spectra')
+    traces = sim_traces(lam, spec, channels)
+    if not traces:
+        raise ValueError('no channels found')
+    header = ','.join(traces.keys())
+    arr = np.column_stack([traces[k] for k in traces])
+    np.savetxt(out_file, arr, delimiter=',', header=header, comments='')
+
+
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog='lgfp')
     sub = parser.add_subparsers(dest='cmd', required=True)
 
     fp_parser = sub.add_parser('fp', help='fingerprint utilities')
     fp_sub = fp_parser.add_subparsers(dest='subcmd', required=True)
-    make_p = fp_sub.add_parser('make')
-    make_p.add_argument('input_folder', type=Path)
+    make_p = fp_sub.add_parser('make', help='create fingerprints')
+    make_p.add_argument('--in', dest='input', type=Path, required=True)
     make_p.add_argument('--out', type=Path, required=True)
 
     lib_parser = sub.add_parser('lib', help='library tools')
     lib_sub = lib_parser.add_subparsers(dest='subcmd', required=True)
-    build_p = lib_sub.add_parser('build')
-    build_p.add_argument('db_folder', type=Path)
+    build_p = lib_sub.add_parser('build', help='build library index')
+    build_p.add_argument('--in', dest='input', type=Path, required=True)
+    build_p.add_argument('--out', type=Path, required=True)
+
+    match_p = sub.add_parser('match', help='match sample against library')
+    match_p.add_argument('--sample', type=Path, required=True)
+    match_p.add_argument('--lib', type=Path, required=True)
+    match_p.add_argument('--top', type=int, default=10)
+    match_p.add_argument('--json', type=Path)
+
+    sim_parser = sub.add_parser('sim', help='SIM utilities')
+    sim_sub = sim_parser.add_subparsers(dest='subcmd', required=True)
+    export_p = sim_sub.add_parser('export', help='export SIM traces')
+    export_p.add_argument('--in', dest='input', type=Path, required=True)
+    export_p.add_argument('--out', type=Path, required=True)
+    export_p.add_argument('--channels', type=str, required=True,
+                         help='comma separated wavelengths')
 
     args = parser.parse_args(argv)
-    if args.cmd == 'fp' and args.subcmd == 'make':
-        fp_make(args.input_folder, args.out)
-    elif args.cmd == 'lib' and args.subcmd == 'build':
-        build_index(args.db_folder)
+    try:
+        if args.cmd == 'fp' and args.subcmd == 'make':
+            fp_make(args.input, args.out)
+        elif args.cmd == 'lib' and args.subcmd == 'build':
+            lib_build(args.input, args.out)
+        elif args.cmd == 'match':
+            match_sample(args.sample, args.lib, args.top, args.json)
+        elif args.cmd == 'sim' and args.subcmd == 'export':
+            channels = [float(c) for c in args.channels.split(',') if c]
+            sim_export(args.input, args.out, channels)
+        return 0
+    except Exception as exc:  # pragma: no cover - CLIs
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
 
 
 if __name__ == '__main__':  # pragma: no cover
-    main()
+    raise SystemExit(main())

--- a/lg_spectra/gui.py
+++ b/lg_spectra/gui.py
@@ -310,6 +310,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self.settings.setValue('accent', self.accent)
         if self.current_folder:
             self.settings.setValue('last_folder', str(self.current_folder))
+        if getattr(self, 'thread', None) and self.thread.isRunning():
+            self.thread.quit()
+            self.thread.wait()
         super().closeEvent(event)
 
 

--- a/lg_spectra/gui.py
+++ b/lg_spectra/gui.py
@@ -7,16 +7,44 @@ from typing import Dict, List, Optional, Tuple
 import json
 import numpy as np
 import pyqtgraph as pg
-from PyQt6 import QtWidgets
+from qt_material import apply_stylesheet
+from PyQt6 import QtCore, QtWidgets
 from PyQt6.QtCore import Qt
-from PyQt6.QtGui import QAction
+from PyQt6.QtGui import QAction, QColor, QCloseEvent
 
 from .io import load_any
-from .preprocess import apply_pipeline
+from .preprocess import apply_pipeline, sanitize_spectrum
 from .sticks import pick_sticks
 from .features import compute_features
 from .library import build_index
 from .matching import score
+from .sim import sim_traces
+
+
+class MatchWorker(QtCore.QObject):
+    progress = QtCore.pyqtSignal(int)
+    finished = QtCore.pyqtSignal(list)
+    message = QtCore.pyqtSignal(str)
+
+    def __init__(self, fp: Dict, library: Dict[str, Dict]) -> None:
+        super().__init__()
+        self.fp = fp
+        self.library = library
+
+    def run(self) -> None:
+        rows = []
+        total = len(self.library) or 1
+        for i, (name, entry) in enumerate(self.library.items()):
+            lib_entry = {
+                'sticks': entry.get('sticks', []),
+                'ratios': entry.get('ratios_mean', []),
+                'bandpower': entry.get('bandpower_mean', []),
+                'hash': entry.get('hash'),
+            }
+            sc = score(self.fp, lib_entry)
+            rows.append((name, sc['S'], sc['S_cos'], sc['S_ratio']))
+            self.progress.emit(int((i + 1) / total * 100))
+        self.finished.emit(rows)
 
 
 class MainWindow(QtWidgets.QMainWindow):
@@ -27,7 +55,17 @@ class MainWindow(QtWidgets.QMainWindow):
         self.library_index: Dict[str, Dict] = {}
         self.current_folder: Optional[Path] = None
         self.loaded_spectra: Dict[str, Tuple[np.ndarray, np.ndarray, Dict]] = {}
+        self.settings = QtCore.QSettings('lg_spectra', 'app')
+        self.dark = self.settings.value('dark', True, bool)
+        self.accent = self.settings.value('accent', 'teal')
+        self._apply_theme()
+        geom = self.settings.value('geometry')
+        if geom:
+            self.restoreGeometry(geom)
         self._init_ui()
+        last = self.settings.value('last_folder')
+        if last:
+            self.load_folder(Path(str(last)))
 
     def _init_ui(self) -> None:
         self.spectra_plot = pg.PlotWidget(title='Spectra')
@@ -35,6 +73,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self.feature_table = QtWidgets.QTableWidget()
         self.match_table = QtWidgets.QTableWidget()
         self.file_list = QtWidgets.QListWidget()
+        self.progress = QtWidgets.QProgressBar()
+        self.log_console = QtWidgets.QTextEdit()
+        self.log_console.setReadOnly(True)
 
         dock1 = QtWidgets.QDockWidget('Spectra', self)
         dock1.setWidget(self.spectra_plot)
@@ -46,12 +87,15 @@ class MainWindow(QtWidgets.QMainWindow):
         dock4.setWidget(self.match_table)
         dock5 = QtWidgets.QDockWidget('Dateien', self)
         dock5.setWidget(self.file_list)
+        dock6 = QtWidgets.QDockWidget('Log', self)
+        dock6.setWidget(self.log_console)
 
         self.addDockWidget(Qt.DockWidgetArea.LeftDockWidgetArea, dock1)
         self.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, dock2)
         self.addDockWidget(Qt.DockWidgetArea.BottomDockWidgetArea, dock3)
         self.addDockWidget(Qt.DockWidgetArea.BottomDockWidgetArea, dock4)
         self.addDockWidget(Qt.DockWidgetArea.LeftDockWidgetArea, dock5)
+        self.addDockWidget(Qt.DockWidgetArea.BottomDockWidgetArea, dock6)
 
         self.file_list.itemSelectionChanged.connect(self._display_selected)
 
@@ -65,17 +109,39 @@ class MainWindow(QtWidgets.QMainWindow):
         match_action.triggered.connect(self.match_spectrum)
         export_action = QAction('Fingerprint exportieren', self)
         export_action.triggered.connect(self.export_fingerprint)
+        sim_action = QAction('Export SIM', self)
+        sim_action.triggered.connect(self.export_sim)
         toolbar = self.addToolBar('Main')
         toolbar.addAction(open_action)
         toolbar.addAction(add_action)
         toolbar.addAction(lib_action)
         toolbar.addAction(match_action)
         toolbar.addAction(export_action)
+        toolbar.addAction(sim_action)
+        self.k_spin = QtWidgets.QSpinBox()
+        self.k_spin.setRange(1, 12)
+        self.k_spin.setValue(6)
+        toolbar.addWidget(self.k_spin)
+        self.pipeline_combo = QtWidgets.QComboBox()
+        self.pipeline_combo.addItems(['snv+savgol', 'snv'])
+        toolbar.addWidget(self.pipeline_combo)
+        self.statusBar().addPermanentWidget(self.progress)
+
+        view_menu = self.menuBar().addMenu('Darstellung')
+        theme_action = QAction('Theme wechseln', self)
+        theme_action.triggered.connect(self.toggle_theme)
+        view_menu.addAction(theme_action)
+        accent_menu = view_menu.addMenu('Akzentfarbe')
+        for col in ['teal', 'blue', 'red', 'orange']:
+            act = QAction(col, self)
+            act.triggered.connect(lambda _, c=col: self.set_accent(c))
+            accent_menu.addAction(act)
 
     def open_folder(self) -> None:
         folder = QtWidgets.QFileDialog.getExistingDirectory(self, 'Ordner wählen')
         if not folder:
             return
+        self.settings.setValue('last_folder', folder)
         self.load_folder(Path(folder))
 
     def open_library(self) -> None:
@@ -96,6 +162,7 @@ class MainWindow(QtWidgets.QMainWindow):
             base = p.name.replace('_lam.npy', '')
             self.loaded_spectra[base] = (lam, spec, meta)
             self.file_list.addItem(base)
+        self.statusBar().showMessage(f'{len(files)} Dateien geladen', 5000)
         if self.file_list.count():
             self.file_list.setCurrentRow(0)
 
@@ -121,6 +188,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.loaded_spectra[base] = (lam, spec, meta)
             if not self.file_list.findItems(base, Qt.MatchFlag.MatchExactly):
                 self.file_list.addItem(base)
+        self.statusBar().showMessage(f'{len(paths)} Dateien hinzugefügt', 5000)
         if self.file_list.count() and self.file_list.currentRow() == -1:
             self.file_list.setCurrentRow(0)
 
@@ -131,11 +199,15 @@ class MainWindow(QtWidgets.QMainWindow):
         base = items[0].text()
         lam, spec, _ = self.loaded_spectra[base]
         y = spec[0] if spec.ndim > 1 else spec
-        y_hat = apply_pipeline(lam, y, [{'op': 'snv'}, {'op': 'savgol', 'win': 7, 'poly': 2}])
+        lam, y, _ = sanitize_spectrum(lam, y)
+        cfg = [{'op': 'snv'}]
+        if self.pipeline_combo.currentText() == 'snv+savgol':
+            cfg.append({'op': 'savgol', 'win': 7, 'poly': 2})
+        y_hat = apply_pipeline(lam, y, cfg)
         self.spectra_plot.clear()
         self.spectra_plot.plot(lam, y, pen='r')
         self.spectra_plot.plot(lam, y_hat, pen='g')
-        sticks = pick_sticks(lam, y_hat, {'k': 6})
+        sticks = pick_sticks(lam, y_hat, {'k': self.k_spin.value()})
         self.ms_plot.clear()
         for s in sticks:
             self.ms_plot.plot([s.lambda_nm, s.lambda_nm], [0, s.rel_intensity], pen='b')
@@ -157,23 +229,33 @@ class MainWindow(QtWidgets.QMainWindow):
     def match_spectrum(self) -> None:
         if not self.current_fp or not self.library_index:
             return
-        rows = []
-        for name, entry in self.library_index.items():
-            lib_entry = {
-                'sticks': entry.get('sticks', []),
-                'ratios': entry.get('ratios_mean', []),
-                'bandpower': entry.get('bandpower_mean', []),
-                'hash': entry.get('hash')
-            }
-            sc = score(self.current_fp, lib_entry)
-            rows.append((name, sc['S'], sc['S_cos'], sc['S_ratio']))
+        self.progress.setValue(0)
+        self.thread = QtCore.QThread(self)
+        self.worker = MatchWorker(self.current_fp, self.library_index)
+        self.worker.moveToThread(self.thread)
+        self.worker.progress.connect(self.progress.setValue)
+        self.worker.finished.connect(self._match_finished)
+        self.thread.started.connect(self.worker.run)
+        self.thread.start()
+
+    def _match_finished(self, rows: List[Tuple[str, float, float, float]]) -> None:
+        self.thread.quit()
+        self.thread.wait()
+        self.progress.setValue(100)
         rows.sort(key=lambda r: r[1], reverse=True)
         self.match_table.setColumnCount(4)
         self.match_table.setHorizontalHeaderLabels(['Analyte', 'Score', 'Cos', 'Ratio'])
         self.match_table.setRowCount(len(rows))
         for i, (name, s_total, s_cos, s_ratio) in enumerate(rows):
             self.match_table.setItem(i, 0, QtWidgets.QTableWidgetItem(name))
-            self.match_table.setItem(i, 1, QtWidgets.QTableWidgetItem(f'{s_total:.3f}'))
+            score_item = QtWidgets.QTableWidgetItem(f'{s_total:.3f}')
+            color = QColor('red')
+            if s_total >= 0.8:
+                color = QColor('green')
+            elif s_total >= 0.5:
+                color = QColor('yellow')
+            score_item.setBackground(color)
+            self.match_table.setItem(i, 1, score_item)
             self.match_table.setItem(i, 2, QtWidgets.QTableWidgetItem(f'{s_cos:.3f}'))
             self.match_table.setItem(i, 3, QtWidgets.QTableWidgetItem(f'{s_ratio:.3f}'))
 
@@ -188,9 +270,53 @@ class MainWindow(QtWidgets.QMainWindow):
         with Path(path).open('w', encoding='utf8') as fh:
             json.dump(self.current_fp, fh, indent=2)
 
+    def export_sim(self) -> None:
+        items = self.file_list.selectedItems()
+        if not items:
+            return
+        base = items[0].text()
+        lam, spec, _ = self.loaded_spectra[base]
+        if spec.ndim != 2:
+            return
+        file, _ = QtWidgets.QFileDialog.getSaveFileName(self, 'SIM export', filter='CSV (*.csv)')
+        if not file:
+            return
+        channels, ok = QtWidgets.QInputDialog.getText(self, 'Kanäle', 'Wellenlängen (comma separated)')
+        if not ok or not channels:
+            return
+        chans = [float(c.strip()) for c in channels.split(',') if c.strip()]
+        traces = sim_traces(lam, spec, chans)
+        if not traces:
+            return
+        arr = np.column_stack([traces[k] for k in traces])
+        header = ','.join(traces.keys())
+        np.savetxt(file, arr, delimiter=',', header=header, comments='')
+
+    def _apply_theme(self) -> None:
+        self.current_theme = f"{'dark' if self.dark else 'light'}_{self.accent}.xml"
+        apply_stylesheet(QtWidgets.QApplication.instance(), theme=self.current_theme)
+
+    def toggle_theme(self) -> None:
+        self.dark = not self.dark
+        self._apply_theme()
+
+    def set_accent(self, accent: str) -> None:
+        self.accent = accent
+        self._apply_theme()
+
+    def closeEvent(self, event: QCloseEvent) -> None:
+        self.settings.setValue('geometry', self.saveGeometry())
+        self.settings.setValue('dark', self.dark)
+        self.settings.setValue('accent', self.accent)
+        if self.current_folder:
+            self.settings.setValue('last_folder', str(self.current_folder))
+        super().closeEvent(event)
+
 
 def run() -> None:
+    QtWidgets.QApplication.setAttribute(QtCore.Qt.ApplicationAttribute.AA_EnableHighDpiScaling, True)
     app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    apply_stylesheet(app, theme='dark_teal.xml')
     win = MainWindow()
     win.resize(800, 600)
     win.show()

--- a/lg_spectra/quality.py
+++ b/lg_spectra/quality.py
@@ -1,0 +1,36 @@
+"""Quality assessment helpers for spectral fingerprints."""
+from __future__ import annotations
+
+from typing import Dict, List, Sequence
+import numpy as np
+
+
+def check_warnings(fp: Dict, lam: Sequence[float] | None = None,
+                   y: Sequence[float] | None = None,
+                   k_min: int = 3, snr_min: float = 10.0) -> List[str]:
+    """Return human readable warnings about fingerprint quality.
+
+    Parameters
+    ----------
+    fp:
+        Fingerprint dictionary containing a ``quality`` section.
+    lam, y:
+        Optional wavelength axis and corresponding intensities to
+        perform additional checks such as absorption above 360 nm.
+    k_min:
+        Minimum required number of sticks.
+    snr_min:
+        Minimum acceptable signal-to-noise ratio.
+    """
+    warnings: List[str] = []
+    q = fp.get('quality', {})
+    if q.get('n_sticks', 0) < k_min:
+        warnings.append(f"n_sticks < {k_min}")
+    if q.get('snr', 0.0) < snr_min:
+        warnings.append(f"snr below {snr_min}")
+    if lam is not None and y is not None:
+        lam_arr = np.asarray(lam)
+        y_arr = np.asarray(y)
+        if not np.any((lam_arr >= 360) & (y_arr > 0)):
+            warnings.append("no absorption >= 360 nm")
+    return warnings

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import numpy as np
+from lg_spectra.features import compute_features
+from lg_spectra.sticks import Stick
+import unittest
+
+
+class QualityWarnTest(unittest.TestCase):
+    def test_quality_warnings(self) -> None:
+        lam = np.linspace(300, 350, 50)
+        y = np.ones_like(lam) * 0.1
+        sticks = []
+        fp = compute_features(lam, y, sticks)
+        warnings = fp.get('warnings', [])
+        self.assertTrue(any('n_sticks' in w for w in warnings))
+        self.assertTrue(any('snr' in w for w in warnings))
+        self.assertTrue(any('360' in w for w in warnings))
+
+
+if __name__ == '__main__':  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add qt-material themed GUI with theme and accent switching, progress bar, and threaded matching
- expand CLI with fingerprint, library, match, and SIM export subcommands
- add spectrum sanitation and quality warning helpers with tests

## Testing
- `python -m unittest tests.test_quality -v`
- `python -m lg_spectra.cli --help`
- `python -m lg_spectra.cli fp make --help`
- `python -m lg_spectra.cli lib build --help`
- `python -m lg_spectra.cli match --help`
- `python -m lg_spectra.cli sim export --help`
- `python - <<'PY'\nfrom PyQt6 import QtWidgets\nfrom lg_spectra.gui import MainWindow\napp = QtWidgets.QApplication([])\nwin = MainWindow()\nprint('GUI init OK')\nPY` *(fails: qt.qpa.plugin: Could not load the Qt platform plugin "xcb")*

------
https://chatgpt.com/codex/tasks/task_e_68c52bf088348331af08efb4e8436f12